### PR TITLE
using git urls for codemirror, showdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "d-barchart": "~0.1.0",
     "d-barchart-vanilla": "~0.1.0",
     "d-d3-barchart": "~0.1.0",
-    "d-codemirror": "~0.1.0",
-    "d-showdown": "~0.1.0"
+    "d-codemirror": "git+https://github.com/codeparty/d-codemirror.git",
+    "d-showdown": "git+https://github.com/codeparty/d-showdown.git"
   },
   "optionalDependencies": {},
   "devDependencies": {},


### PR DESCRIPTION
`d-codemirror` and `d-showdown` are not on npm, so `npm install` fails.

This fix is pretty weak, but could actually be legitimate, I guess, if the intent of the examples is to be a bleeding edge test-bed.

Figured I'd close the loop on today's frustration, started over at [derby-templates](https://github.com/codeparty/derby-templates/issues/3), and continued in rediscovering this over at [derby-starter](https://github.com/codeparty/derby-starter/pull/4).
