### PR TITLE
tie to specific derby version for npm 2 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.7.1",
-    "derby": "^0.6",
+    "derby": "0.6.0-alpha28",
     "derby-starter": "^0.2.3",
     "derby-stylus": "~0.1.0",
     "express": "~3.18.0",


### PR DESCRIPTION
Changed package.json in a similar way to https://github.com/derbyjs/derby/commit/1c5c1654062c66a1efd38dbb9ebc11e0d44aed22 so that derby-examples can run with npm 2.x
