### PR TITLE
Adapt to auto load mode codemirror

### DIFF
--- a/codemirror/index.html
+++ b/codemirror/index.html
@@ -3,13 +3,16 @@
   <view name="d-showdown:includes" static='/showdown'></view>
 <Body:>
   <!--Templates define both HTML and model-view bindings-->
-  <h2>CodeMirror Example</h2>
-  <div>
+  <header>
+    <h1>CodeMirror Example</h1>
+  </header>
+
+  <section id="mirror-wrapper">
     <view name="d-codemirror" text="{{codemirror.text}}" options="{{ { tabSize: 2, mode: 'markdown' } }}"></view>
-  </div>
-  <div>
+  </section>
+  <section>
     <view name="d-showdown" text="{{codemirror.text}}" html="{{_page.markdown}}" options="{{ {} }}"></view>
     <div as="md"></div>
     {{markdown(_page.markdown)}}
-  </div>
+  </section>
 

--- a/codemirror/index.html
+++ b/codemirror/index.html
@@ -1,12 +1,11 @@
 <Head:>
   <view name="d-codemirror:includes" static='/cm'></view>
   <view name="d-showdown:includes" static='/showdown'></view>
-  <script src="/md/markdown.js"></script>
 <Body:>
   <!--Templates define both HTML and model-view bindings-->
   <h2>CodeMirror Example</h2>
   <div>
-    <view name="d-codemirror" text="{{codemirror.text}}" options="{{ { tabSize: 2, mode: 'html/markdown' } }}"></view>
+    <view name="d-codemirror" text="{{codemirror.text}}" options="{{ { tabSize: 2, mode: 'markdown' } }}"></view>
   </div>
   <div>
     <view name="d-showdown" text="{{codemirror.text}}" html="{{_page.markdown}}" options="{{ {} }}"></view>

--- a/codemirror/index.js
+++ b/codemirror/index.js
@@ -15,4 +15,4 @@ app.get('/', function(page, model) {
 app.proto.markdown = function(html) {
   if(!this.md) return;
   this.md.innerHTML = html;
-}
+};

--- a/codemirror/index.js
+++ b/codemirror/index.js
@@ -1,6 +1,8 @@
 var app = module.exports = require('derby').createApp('codemirror', __filename);
 app.use(require('derby-debug'));
+app.serverUse(module, 'derby-stylus');
 app.loadViews(__dirname);
+app.loadStyles(__dirname);
 app.component(require('d-codemirror'));
 app.component(require('d-showdown'));
 

--- a/codemirror/index.styl
+++ b/codemirror/index.styl
@@ -1,0 +1,30 @@
+@import "../node_modules/derby-starter/styles/reset.css"
+
+body {
+  color: #000;
+  background: #f7f7f7;
+}
+h1 {
+  font: 26px/24px "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: bold;
+  letter-spacing: -1px;
+  margin-bottom: 12px;
+  color: #111;
+  text-shadow: 0 1px #f7f7f7;
+}
+
+header {
+  background: #ddd;
+  background: linear-gradient(#e7e7e7, #d0d0d0);
+  box-shadow: inset 0 1px #f7f7f7, 0 1px #888, 0 2px #e7e7e7;
+  padding: 12px 16px;
+  white-space: nowrap;
+}
+
+section {
+  padding: 12px 16px;
+}
+
+section#mirror-wrapper {
+  background-color: white;
+}

--- a/codemirror/server.js
+++ b/codemirror/server.js
@@ -6,8 +6,7 @@ var showdown = node_modules + "d-showdown/node_modules/showdown/compressed";
 var options = {
   port: 8003,
   static: [
-    {route: '/cm', dir: cm + 'lib'},
-    {route: '/md', dir: cm + 'mode/markdown'},
+    {route: '/cm', dir: cm },
     {route: '/showdown', dir: showdown}
   ]
 };


### PR DESCRIPTION
This is to accommodate https://github.com/derbyjs/d-codemirror/pull/2

Additionally, I added styles to make it look more like the Todos example. If this is not needed feel free to only apply the first commit.

Best,