### PR TITLE
Cross browser fixes

### DIFF
--- a/directory/index.js
+++ b/directory/index.js
@@ -59,7 +59,7 @@ EditForm.prototype.done = function() {
     });
     model.set('nameError', true);
     this.nameInput.focus();
-    return false;
+    return;
   }
 
   if (!model.get('person.id')) {
@@ -72,7 +72,6 @@ EditForm.prototype.done = function() {
   } else {
     app.history.push('/people');
   }
-  return false;
 };
 
 EditForm.prototype.cancel = function() {

--- a/directory/index.js
+++ b/directory/index.js
@@ -64,6 +64,8 @@ EditForm.prototype.done = function() {
 
   if (!model.get('person.id')) {
     model.root.add('people', model.get('person'));
+    // Wait for all model changes to go through before going to the next page, mainly because
+    // in non-single-page-app mode (basically IE < 10) we want changes to save to the server before leaving the page
     model.whenNothingPending(function(){
       app.history.push('/people');
     });
@@ -80,6 +82,8 @@ EditForm.prototype.cancel = function() {
 EditForm.prototype.deletePerson = function() {
   // Update model without emitting events so that the page doesn't update
   this.model.silent().del('person');
+  // Wait for all model changes to go through before going back, mainly because
+  // in non-single-page-app mode (basically IE < 10) we want changes to save to the server before leaving the page
   this.model.whenNothingPending(function(){
     app.history.back();
   });

--- a/directory/index.js
+++ b/directory/index.js
@@ -59,13 +59,18 @@ EditForm.prototype.done = function() {
     });
     model.set('nameError', true);
     this.nameInput.focus();
-    return;
+    return false;
   }
 
   if (!model.get('person.id')) {
     model.root.add('people', model.get('person'));
+    model.whenNothingPending(function(){
+      app.history.push('/people');
+    });
+  } else {
+    app.history.push('/people');
   }
-  app.history.push('/people');
+  return false;
 };
 
 EditForm.prototype.cancel = function() {
@@ -75,5 +80,7 @@ EditForm.prototype.cancel = function() {
 EditForm.prototype.deletePerson = function() {
   // Update model without emitting events so that the page doesn't update
   this.model.silent().del('person');
-  app.history.back();
+  this.model.whenNothingPending(function(){
+    app.history.back();
+  });
 };

--- a/directory/views/edit.html
+++ b/directory/views/edit.html
@@ -35,7 +35,7 @@
           </dropdown>
         </field>
         <field label="Phone">
-          <input type="phone" class="form-control" value="{{person.phone}}">
+          <input type="tel" class="form-control" value="{{person.phone}}">
         </field>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.7.1",
-    "derby": "0.6.0-alpha29",
+    "derby": "0.6.0-alpha35",
     "derby-starter": "^0.2.6",
     "derby-stylus": "~0.1.0",
     "express": "~3.18.0",


### PR DESCRIPTION
Bugs fixed:

* 'Add Somebody' page wasn't working in the directory example due to an input having the wrong type set
* Updated the derby version since it was causing problems
* History wasn't being used correctly because the directory example wasn't written to work in non-single-page-app mode, which broke stuff in IE9