### PR TITLE
Upgrade node to v6.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # RUN-USING: docker run --name derby-examples --rm derbyjs/derby-examples
 
 # specify base docker image
-FROM dockerfile/nodejs
+FROM node:6.10.3
 
 # copy over dependencies
 WORKDIR /var
@@ -21,7 +21,7 @@ ADD widgets /var/derby-examples/widgets
 
 # npm install all the things
 WORKDIR /var/derby-examples
-RUN npm install
+RUN npm_config_spin=false npm_config_loglevel=warn npm install --production
 
 # expose any ports we need
 EXPOSE 8001


### PR DESCRIPTION
Changes:
* Upgrade Dockerfile to use the node v6.10.3 docker image (the current image being used is very old).
* Reduce the npm logging to `warn` and only install production modules when building the docker image